### PR TITLE
Make clj-http-lite lighter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ aws.clj
 *.pyc
 .lein-failures
 /.lein-deps-sum
+/.lein-repl-history

--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,1 @@
-{:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.6.0"}
-        slingshot {:mvn/version "0.12.1"}}}
+{:paths ["src"]}

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :warn-on-reflection false
   :license {:name "MIT"
             :url "http://www.opensource.org/licenses/mit-license.php"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [slingshot "0.12.2"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
   :profiles {:dev {:dependencies [[ring/ring-jetty-adapter "1.3.2"]
                                   [ring/ring-devel "1.3.2"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}

--- a/src/clj_http/lite/client.clj
+++ b/src/clj_http/lite/client.clj
@@ -8,6 +8,8 @@
   (:import [java.net UnknownHostException])
   (:refer-clojure :exclude (get update)))
 
+(set! *warn-on-reflection* true)
+
 (defn update [m k f & args]
   (assoc m k (apply f (m k) args)))
 

--- a/src/clj_http/lite/client.clj
+++ b/src/clj_http/lite/client.clj
@@ -1,13 +1,11 @@
 (ns clj-http.lite.client
   "Batteries-included HTTP client."
-  (:use [slingshot.slingshot :only [throw+]])
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [clj-http.lite.core :as core]
             [clj-http.lite.links :refer [wrap-links]]
             [clj-http.lite.util :as util])
-  (:import (java.io InputStream File)
-           (java.net URL UnknownHostException))
+  (:import [java.net UnknownHostException])
   (:refer-clojure :exclude (get update)))
 
 (defn update [m k f & args]
@@ -34,7 +32,7 @@
       (if (or (not (clojure.core/get req :throw-exceptions true))
               (unexceptional-status? status))
         resp
-        (throw+ resp "clj-http: status %s" (:status %))))))
+        (throw (Exception. (format "clj-http: status %s" (:status resp))))))))
 
 (declare wrap-redirects)
 
@@ -73,7 +71,7 @@
       (if body
         (cond
          (keyword? as)
-         (condp = as
+         (case as
            ;; Don't do anything for streams
            :stream resp
            ;; Don't do anything when it's a byte-array

--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -4,6 +4,8 @@
   (:import (java.io ByteArrayOutputStream InputStream)
            (java.net URL HttpURLConnection)))
 
+(set! *warn-on-reflection* true)
+
 (defn parse-headers
   "Takes a URLConnection and returns a map of names to values.
 
@@ -53,7 +55,7 @@
                       (when server-port (str ":" server-port))
                       uri
                       (when query-string (str "?" query-string)))
-        conn (.openConnection ^URL (URL. http-url))]
+        conn ^HttpURLConnection (.openConnection ^URL (URL. http-url))]
     (when (and content-type character-encoding)
       (.setRequestProperty conn "Content-Type" (str content-type
                                                     "; charset="
@@ -63,8 +65,8 @@
     (doseq [[h v] headers]
       (.setRequestProperty conn h v))
     (when (false? follow-redirects)
-      (.setInstanceFollowRedirects ^HttpURLConnection conn false))
-    (.setRequestMethod ^HttpURLConnection conn (.toUpperCase (name request-method)))
+      (.setInstanceFollowRedirects conn false))
+    (.setRequestMethod conn (.toUpperCase (name request-method)))
     (when body
       (.setDoOutput conn true))
     (when socket-timeout

--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -1,8 +1,8 @@
 (ns clj-http.lite.core
   "Core HTTP request/response implementation."
   (:require [clojure.java.io :as io])
-  (:import (java.io ByteArrayOutputStream InputStream IOException)
-           (java.net URI URL HttpURLConnection)))
+  (:import (java.io ByteArrayOutputStream InputStream)
+           (java.net URL HttpURLConnection)))
 
 (defn parse-headers
   "Takes a URLConnection and returns a map of names to values.

--- a/src/clj_http/lite/links.clj
+++ b/src/clj_http/lite/links.clj
@@ -3,6 +3,8 @@
 
   Imported from https://github.com/dakrone/clj-http/blob/217393258e7863514debece4eb7b23a7a3fa8bd9/src/clj_http/links.clj")
 
+(set! *warn-on-reflection* true)
+
 (def ^:private quoted-string
   #"\"((?:[^\"]|\\\")*)\"")
 

--- a/src/clj_http/lite/util.clj
+++ b/src/clj_http/lite/util.clj
@@ -6,6 +6,8 @@
            (java.util.zip InflaterInputStream DeflaterInputStream
                           GZIPInputStream GZIPOutputStream)))
 
+(set! *warn-on-reflection* true)
+
 (defn utf8-bytes
   "Returns the UTF-8 bytes corresponding to the given string."
   [#^String s]

--- a/src/clj_http/lite/util.clj
+++ b/src/clj_http/lite/util.clj
@@ -31,12 +31,7 @@
 (defmacro base64-encode
   "Encode an array of bytes into a base64 encoded string."
   [unencoded]
-  (if (try (import 'javax.xml.bind.DatatypeConverter)
-           (catch ClassNotFoundException _))
-    `(javax.xml.bind.DatatypeConverter/printBase64Binary ~unencoded)
-    (do
-      (import 'java.util.Base64)
-      `(.encodeToString (java.util.Base64/getEncoder) ~unencoded))))
+  `(.encodeToString (java.util.Base64/getEncoder) ~unencoded))
 
 (defn to-byte-array
   "Returns a byte array for the InputStream provided."


### PR DESCRIPTION
- Remove dependency on slingshot
- Assume JDK8 or higher (no need to depend on javax.xml)